### PR TITLE
Make compatible with ClojureScript

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ This library offers improved integration with the semantic-ui-react package with
 factories and doc strings generated directly from the Semantic-UI source. It also includes symbols for 
 all icon names.
 
-NOTE: This library requires that you use Fulcro 3 and is only tested with Shadow CLJS as the compiler.
+NOTE: This library requires that you use Fulcro 3.
 
 image::https://img.shields.io/clojars/v/com.fulcrologic/semantic-ui-wrapper.svg[link="https://clojars.org/com.fulcrologic/semantic-ui-wrapper"]
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src/main"]
  :deps    {}
  :aliases {:dev {:extra-paths ["src/workspaces" "src/dev"]
-                 :extra-deps  {org.clojure/clojure         {:mvn/version "1.10.0" :scope "provided"}
-                               org.clojure/clojurescript   {:mvn/version "1.10.773" :scope "provided"}
-                               com.fulcrologic/fulcro      {:mvn/version "3.4.4" :scope "provided"}
-                               thheller/shadow-cljs        {:mvn/version "2.11.8"}
-                               com.github.awkay/workspaces {:mvn/version "1.0.2"}}}}}
+                 :extra-deps  {org.clojure/clojure         {:mvn/version "1.10.3" :scope "provided"}
+                               org.clojure/clojurescript   {:mvn/version "1.10.844" :scope "provided"}
+                               com.fulcrologic/fulcro      {:mvn/version "3.5.20" :scope "provided"}
+                               thheller/shadow-cljs        {:mvn/version "2.12.6"}
+                               com.github.awkay/workspaces {:mvn/version "1.0.3"}}}}}

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.fulcrologic</groupId>
             <artifactId>fulcro</artifactId>
-            <version>3.4.4</version>
+            <version>3.5.20</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/com/fulcrologic/semantic_ui/addons/confirm/ui_confirm.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/confirm/ui_confirm.cljc
@@ -1,10 +1,10 @@
 (ns com.fulcrologic.semantic-ui.addons.confirm.ui-confirm
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Confirm/Confirm" :default Confirm]))
+    ["semantic-ui-react$Confirm" :as Confirm]))
 
   (def ui-confirm
-  "A Confirm modal gives the user a choice to confirm or cancel an action/
+  "A Confirm modal gives the user a choice to confirm or cancel an action.
 
   Props:
     - cancelButton (custom): The cancel button text.

--- a/src/main/com/fulcrologic/semantic_ui/addons/pagination/ui_pagination.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/pagination/ui_pagination.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.pagination.ui-pagination
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Pagination/Pagination" :default Pagination]))
+    ["semantic-ui-react$Pagination" :as Pagination]))
 
   (def ui-pagination
   "A component to render a pagination.

--- a/src/main/com/fulcrologic/semantic_ui/addons/pagination/ui_pagination_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/pagination/ui_pagination_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.pagination.ui-pagination-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Pagination/PaginationItem" :default PaginationItem]))
+    ["semantic-ui-react$PaginationItem" :as PaginationItem]))
 
   (def ui-pagination-item
   "An item of a pagination.

--- a/src/main/com/fulcrologic/semantic_ui/addons/portal/ui_portal.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/portal/ui_portal.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.portal.ui-portal
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Portal/Portal" :default Portal]))
+    ["semantic-ui-react$Portal" :as Portal]))
 
   (def ui-portal
   "A component that allows you to render children outside their parent.

--- a/src/main/com/fulcrologic/semantic_ui/addons/portal/ui_portal_inner.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/portal/ui_portal_inner.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.portal.ui-portal-inner
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Portal/PortalInner" :default PortalInner]))
+    ["semantic-ui-react$PortalInner" :as PortalInner]))
 
   (def ui-portal-inner
   "An inner component that allows you to render children outside their parent.

--- a/src/main/com/fulcrologic/semantic_ui/addons/radio/ui_radio.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/radio/ui_radio.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.radio.ui-radio
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Radio/Radio" :default Radio]))
+    ["semantic-ui-react$Radio" :as Radio]))
 
   (def ui-radio
   "A Radio is sugar for <Checkbox radio />.

--- a/src/main/com/fulcrologic/semantic_ui/addons/select/ui_select.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/select/ui_select.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.select.ui-select
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/Select/Select" :default Select]))
+    ["semantic-ui-react$Select" :as Select]))
 
   (def ui-select
   "A Select is sugar for <Dropdown selection />.

--- a/src/main/com/fulcrologic/semantic_ui/addons/textarea/ui_text_area.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/textarea/ui_text_area.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.textarea.ui-text-area
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/TextArea/TextArea" :default TextArea]))
+    ["semantic-ui-react$TextArea" :as TextArea]))
 
   (def ui-text-area
   "A TextArea can be used to allow for extended user input.

--- a/src/main/com/fulcrologic/semantic_ui/addons/transitionableportal/ui_transitionable_portal.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/addons/transitionableportal/ui_transitionable_portal.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.addons.transitionableportal.ui-transitionable-portal
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/addons/TransitionablePortal/TransitionablePortal" :default TransitionablePortal]))
+    ["semantic-ui-react$TransitionablePortal" :as TransitionablePortal]))
 
   (def ui-transitionable-portal
   "A sugar for `Portal` and `Transition`.

--- a/src/main/com/fulcrologic/semantic_ui/behaviors/visibility/ui_visibility.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/behaviors/visibility/ui_visibility.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.behaviors.visibility.ui-visibility
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/behaviors/Visibility/Visibility" :default Visibility]))
+    ["semantic-ui-react$Visibility" :as Visibility]))
 
   (def ui-visibility
   "Visibility provides a set of callbacks for when a content appears in the viewport.

--- a/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.breadcrumb.ui-breadcrumb
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Breadcrumb/Breadcrumb" :default Breadcrumb]))
+    ["semantic-ui-react$Breadcrumb" :as Breadcrumb]))
 
   (def ui-breadcrumb
   "A breadcrumb is used to show hierarchy between content.

--- a/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb_divider.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb_divider.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.breadcrumb.ui-breadcrumb-divider
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Breadcrumb/BreadcrumbDivider" :default BreadcrumbDivider]))
+    ["semantic-ui-react$BreadcrumbDivider" :as BreadcrumbDivider]))
 
   (def ui-breadcrumb-divider
   "A divider sub-component for Breadcrumb component.

--- a/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb_section.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/breadcrumb/ui_breadcrumb_section.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.breadcrumb.ui-breadcrumb-section
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Breadcrumb/BreadcrumbSection" :default BreadcrumbSection]))
+    ["semantic-ui-react$BreadcrumbSection" :as BreadcrumbSection]))
 
   (def ui-breadcrumb-section
   "A section sub-component for Breadcrumb component.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/Form" :default Form]))
+    ["semantic-ui-react$Form" :as Form]))
 
   (def ui-form
   "A Form displays a set of related user input fields in a structured way.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_button.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_button.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-button
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormButton" :default FormButton]))
+    ["semantic-ui-react$FormButton" :as FormButton]))
 
   (def ui-form-button
   "Sugar for <Form.Field control={Button} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_checkbox.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_checkbox.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-checkbox
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormCheckbox" :default FormCheckbox]))
+    ["semantic-ui-react$FormCheckbox" :as FormCheckbox]))
 
   (def ui-form-checkbox
   "Sugar for <Form.Field control={Checkbox} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_dropdown.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_dropdown.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-dropdown
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormDropdown" :default FormDropdown]))
+    ["semantic-ui-react$FormDropdown" :as FormDropdown]))
 
   (def ui-form-dropdown
   "Sugar for <Form.Field control={Dropdown} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_field.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_field.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-field
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormField" :default FormField]))
+    ["semantic-ui-react$FormField" :as FormField]))
 
   (def ui-form-field
   "A field is a form element containing a label and an input.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormGroup" :default FormGroup]))
+    ["semantic-ui-react$FormGroup" :as FormGroup]))
 
   (def ui-form-group
   "A set of fields can appear grouped together.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_input.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_input.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-input
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormInput" :default FormInput]))
+    ["semantic-ui-react$FormInput" :as FormInput]))
 
   (def ui-form-input
   "Sugar for <Form.Field control={Input} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_radio.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_radio.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-radio
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormRadio" :default FormRadio]))
+    ["semantic-ui-react$FormRadio" :as FormRadio]))
 
   (def ui-form-radio
   "Sugar for <Form.Field control={Radio} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_select.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_select.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-select
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormSelect" :default FormSelect]))
+    ["semantic-ui-react$FormSelect" :as FormSelect]))
 
   (def ui-form-select
   "Sugar for <Form.Field control={Select} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_text_area.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/form/ui_form_text_area.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.form.ui-form-text-area
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Form/FormTextArea" :default FormTextArea]))
+    ["semantic-ui-react$FormTextArea" :as FormTextArea]))
 
   (def ui-form-text-area
   "Sugar for <Form.Field control={TextArea} />.

--- a/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.grid.ui-grid
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Grid/Grid" :default Grid]))
+    ["semantic-ui-react$Grid" :as Grid]))
 
   (def ui-grid
   "A grid is used to harmonize negative space in a layout.

--- a/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid_column.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid_column.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.grid.ui-grid-column
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Grid/GridColumn" :default GridColumn]))
+    ["semantic-ui-react$GridColumn" :as GridColumn]))
 
   (def ui-grid-column
   "A column sub-component for Grid.

--- a/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid_row.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/grid/ui_grid_row.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.grid.ui-grid-row
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Grid/GridRow" :default GridRow]))
+    ["semantic-ui-react$GridRow" :as GridRow]))
 
   (def ui-grid-row
   "A row sub-component for Grid.

--- a/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.menu.ui-menu
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Menu/Menu" :default Menu]))
+    ["semantic-ui-react$Menu" :as Menu]))
 
   (def ui-menu
   "A menu displays grouped navigation actions.

--- a/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.menu.ui-menu-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Menu/MenuHeader" :default MenuHeader]))
+    ["semantic-ui-react$MenuHeader" :as MenuHeader]))
 
   (def ui-menu-header
   "A menu item may include a header or may itself be a header.

--- a/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.menu.ui-menu-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Menu/MenuItem" :default MenuItem]))
+    ["semantic-ui-react$MenuItem" :as MenuItem]))
 
   (def ui-menu-item
   "A menu can contain an item.

--- a/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_menu.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/menu/ui_menu_menu.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.menu.ui-menu-menu
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Menu/MenuMenu" :default MenuMenu]))
+    ["semantic-ui-react$MenuMenu" :as MenuMenu]))
 
   (def ui-menu-menu
   "A menu can contain a sub menu.

--- a/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.message.ui-message
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Message/Message" :default Message]))
+    ["semantic-ui-react$Message" :as Message]))
 
   (def ui-message
   "A message displays information that explains nearby content.

--- a/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.message.ui-message-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Message/MessageContent" :default MessageContent]))
+    ["semantic-ui-react$MessageContent" :as MessageContent]))
 
   (def ui-message-content
   "A message can contain a content.

--- a/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.message.ui-message-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Message/MessageHeader" :default MessageHeader]))
+    ["semantic-ui-react$MessageHeader" :as MessageHeader]))
 
   (def ui-message-header
   "A message can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.message.ui-message-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Message/MessageItem" :default MessageItem]))
+    ["semantic-ui-react$MessageItem" :as MessageItem]))
 
   (def ui-message-item
   "A message list can contain an item.

--- a/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_list.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/message/ui_message_list.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.message.ui-message-list
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Message/MessageList" :default MessageList]))
+    ["semantic-ui-react$MessageList" :as MessageList]))
 
   (def ui-message-list
   "A message can contain a list of items.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/Table" :default Table]))
+    ["semantic-ui-react$Table" :as Table]))
 
   (def ui-table
   "A table displays a collections of data grouped into rows.
@@ -10,7 +10,7 @@
     - as (elementType): An element type to render as (string or function).
     - attached (bool|enum): Attach table to other content (top, bottom)
     - basic (enum|bool): A table can reduce its complexity to increase readability. (very)
-    - celled (bool): A table may be divided each row into separate cells.
+    - celled (bool): A table may be divided into individual cells.
     - children (node): Primary content.
     - className (string): Additional classes.
     - collapsing (bool): A table can be collapsing, taking up only as much space as its rows.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_body.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_body.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-body
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableBody" :default TableBody]))
+    ["semantic-ui-react$TableBody" :as TableBody]))
 
   (def ui-table-body
   "

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_cell.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_cell.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-cell
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableCell" :default TableCell]))
+    ["semantic-ui-react$TableCell" :as TableCell]))
 
   (def ui-table-cell
   "A table row can have cells.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_footer.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_footer.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-footer
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableFooter" :default TableFooter]))
+    ["semantic-ui-react$TableFooter" :as TableFooter]))
 
   (def ui-table-footer
   "A table can have a footer.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableHeader" :default TableHeader]))
+    ["semantic-ui-react$TableHeader" :as TableHeader]))
 
   (def ui-table-header
   "A table can have a header.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_header_cell.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_header_cell.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-header-cell
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableHeaderCell" :default TableHeaderCell]))
+    ["semantic-ui-react$TableHeaderCell" :as TableHeaderCell]))
 
   (def ui-table-header-cell
   "A table can have a header cell.

--- a/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_row.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/collections/table/ui_table_row.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.collections.table.ui-table-row
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/collections/Table/TableRow" :default TableRow]))
+    ["semantic-ui-react$TableRow" :as TableRow]))
 
   (def ui-table-row
   "A table can have rows.

--- a/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.button.ui-button
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Button/Button" :default Button]))
+    ["semantic-ui-react$Button" :as Button]))
 
   (def ui-button
   "A Button indicates a possible user action.
@@ -34,5 +34,6 @@
     - secondary (bool): A button can be formatted to show different levels of emphasis.
     - size (enum): A button can have different sizes. (mini, tiny, small, medium, large, big, huge, massive)
     - tabIndex (number|string): A button can receive focus. ()
-    - toggle (bool): A button can be formatted to toggle on and off."
+    - toggle (bool): A button can be formatted to toggle on and off.
+    - type (enum): The type of the HTML element. (button, submit, reset)"
    #?(:cljs (h/factory-apply Button)))

--- a/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.button.ui-button-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Button/ButtonContent" :default ButtonContent]))
+    ["semantic-ui-react$ButtonContent" :as ButtonContent]))
 
   (def ui-button-content
   "Used in some Button types, such as `animated`.

--- a/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.button.ui-button-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Button/ButtonGroup" :default ButtonGroup]))
+    ["semantic-ui-react$ButtonGroup" :as ButtonGroup]))
 
   (def ui-button-group
   "Buttons can be grouped.

--- a/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_or.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/button/ui_button_or.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.button.ui-button-or
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Button/ButtonOr" :default ButtonOr]))
+    ["semantic-ui-react$ButtonOr" :as ButtonOr]))
 
   (def ui-button-or
   "Button groups can contain conditionals.

--- a/src/main/com/fulcrologic/semantic_ui/elements/container/ui_container.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/container/ui_container.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.container.ui-container
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Container/Container" :default Container]))
+    ["semantic-ui-react$Container" :as Container]))
 
   (def ui-container
   "A container limits content to a maximum width.

--- a/src/main/com/fulcrologic/semantic_ui/elements/divider/ui_divider.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/divider/ui_divider.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.divider.ui-divider
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Divider/Divider" :default Divider]))
+    ["semantic-ui-react$Divider" :as Divider]))
 
   (def ui-divider
   "A divider visually segments content into groups.

--- a/src/main/com/fulcrologic/semantic_ui/elements/flag/ui_flag.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/flag/ui_flag.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.flag.ui-flag
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Flag/Flag" :default Flag]))
+    ["semantic-ui-react$Flag" :as Flag]))
 
   (def ui-flag
   "A flag is is used to represent a political state.

--- a/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.header.ui-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Header/Header" :default Header]))
+    ["semantic-ui-react$Header" :as Header]))
 
   (def ui-header
   "A header provides a short summary of content

--- a/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.header.ui-header-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Header/HeaderContent" :default HeaderContent]))
+    ["semantic-ui-react$HeaderContent" :as HeaderContent]))
 
   (def ui-header-content
   "Header content wraps the main content when there is an adjacent Icon or Image.

--- a/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header_subheader.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/header/ui_header_subheader.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.header.ui-header-subheader
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Header/HeaderSubheader" :default HeaderSubheader]))
+    ["semantic-ui-react$HeaderSubheader" :as HeaderSubheader]))
 
   (def ui-header-subheader
   "Headers may contain subheaders.

--- a/src/main/com/fulcrologic/semantic_ui/elements/icon/ui_icon.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/icon/ui_icon.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.icon.ui-icon
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Icon/Icon" :default Icon]))
+    ["semantic-ui-react$Icon" :as Icon]))
 
   (def ui-icon
   "An icon is a glyph used to represent something else.

--- a/src/main/com/fulcrologic/semantic_ui/elements/icon/ui_icon_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/icon/ui_icon_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.icon.ui-icon-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Icon/IconGroup" :default IconGroup]))
+    ["semantic-ui-react$IconGroup" :as IconGroup]))
 
   (def ui-icon-group
   "Several icons can be used together as a group.

--- a/src/main/com/fulcrologic/semantic_ui/elements/image/ui_image.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/image/ui_image.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.image.ui-image
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Image/Image" :default Image]))
+    ["semantic-ui-react$Image" :as Image]))
 
   (def ui-image
   "An image is a graphic representation of something.

--- a/src/main/com/fulcrologic/semantic_ui/elements/image/ui_image_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/image/ui_image_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.image.ui-image-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Image/ImageGroup" :default ImageGroup]))
+    ["semantic-ui-react$ImageGroup" :as ImageGroup]))
 
   (def ui-image-group
   "A group of images.

--- a/src/main/com/fulcrologic/semantic_ui/elements/input/ui_input.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/input/ui_input.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.input.ui-input
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Input/Input" :default Input]))
+    ["semantic-ui-react$Input" :as Input]))
 
   (def ui-input
   "An Input is a field used to elicit a response from a user.

--- a/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.label.ui-label
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Label/Label" :default Label]))
+    ["semantic-ui-react$Label" :as Label]))
 
   (def ui-label
   "A label displays content classification.

--- a/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label_detail.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label_detail.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.label.ui-label-detail
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Label/LabelDetail" :default LabelDetail]))
+    ["semantic-ui-react$LabelDetail" :as LabelDetail]))
 
   (def ui-label-detail
   "

--- a/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/label/ui_label_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.label.ui-label-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Label/LabelGroup" :default LabelGroup]))
+    ["semantic-ui-react$LabelGroup" :as LabelGroup]))
 
   (def ui-label-group
   "A label can be grouped.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/List" :default List]))
+    ["semantic-ui-react$List" :as List]))
 
   (def ui-list
   "A list groups related content.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListContent" :default ListContent]))
+    ["semantic-ui-react$ListContent" :as ListContent]))
 
   (def ui-list-content
   "A list item can contain a content.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_description.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_description.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-description
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListDescription" :default ListDescription]))
+    ["semantic-ui-react$ListDescription" :as ListDescription]))
 
   (def ui-list-description
   "A list item can contain a description.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListHeader" :default ListHeader]))
+    ["semantic-ui-react$ListHeader" :as ListHeader]))
 
   (def ui-list-header
   "A list item can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_icon.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_icon.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-icon
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListIcon" :default ListIcon]))
+    ["semantic-ui-react$ListIcon" :as ListIcon]))
 
   (def ui-list-icon
   "A list item can contain an icon.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListItem" :default ListItem]))
+    ["semantic-ui-react$ListItem" :as ListItem]))
 
   (def ui-list-item
   "A list item can contain a set of items.

--- a/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_list.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/list/ui_list_list.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.list.ui-list-list
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/List/ListList" :default ListList]))
+    ["semantic-ui-react$ListList" :as ListList]))
 
   (def ui-list-list
   "A list can contain a sub list.

--- a/src/main/com/fulcrologic/semantic_ui/elements/loader/ui_loader.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/loader/ui_loader.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.loader.ui-loader
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Loader/Loader" :default Loader]))
+    ["semantic-ui-react$Loader" :as Loader]))
 
   (def ui-loader
   "A loader alerts a user to wait for an activity to complete.

--- a/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.placeholder.ui-placeholder
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Placeholder/Placeholder" :default Placeholder]))
+    ["semantic-ui-react$Placeholder" :as Placeholder]))
 
   (def ui-placeholder
   "A placeholder is used to reserve space for content that soon will appear in a layout.

--- a/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.placeholder.ui-placeholder-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Placeholder/PlaceholderHeader" :default PlaceholderHeader]))
+    ["semantic-ui-react$PlaceholderHeader" :as PlaceholderHeader]))
 
   (def ui-placeholder-header
   "A placeholder can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_image.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_image.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.placeholder.ui-placeholder-image
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Placeholder/PlaceholderImage" :default PlaceholderImage]))
+    ["semantic-ui-react$PlaceholderImage" :as PlaceholderImage]))
 
   (def ui-placeholder-image
   "A placeholder can contain an image.

--- a/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_line.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_line.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.placeholder.ui-placeholder-line
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Placeholder/PlaceholderLine" :default PlaceholderLine]))
+    ["semantic-ui-react$PlaceholderLine" :as PlaceholderLine]))
 
   (def ui-placeholder-line
   "A placeholder can contain have lines of text.

--- a/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_paragraph.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/placeholder/ui_placeholder_paragraph.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.placeholder.ui-placeholder-paragraph
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Placeholder/PlaceholderParagraph" :default PlaceholderParagraph]))
+    ["semantic-ui-react$PlaceholderParagraph" :as PlaceholderParagraph]))
 
   (def ui-placeholder-paragraph
   "A placeholder can contain a paragraph.

--- a/src/main/com/fulcrologic/semantic_ui/elements/rail/ui_rail.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/rail/ui_rail.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.rail.ui-rail
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Rail/Rail" :default Rail]))
+    ["semantic-ui-react$Rail" :as Rail]))
 
   (def ui-rail
   "A rail is used to show accompanying content outside the boundaries of the main view of a site.

--- a/src/main/com/fulcrologic/semantic_ui/elements/reveal/ui_reveal.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/reveal/ui_reveal.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.reveal.ui-reveal
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Reveal/Reveal" :default Reveal]))
+    ["semantic-ui-react$Reveal" :as Reveal]))
 
   (def ui-reveal
   "A reveal displays additional content in place of previous content when activated.

--- a/src/main/com/fulcrologic/semantic_ui/elements/reveal/ui_reveal_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/reveal/ui_reveal_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.reveal.ui-reveal-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Reveal/RevealContent" :default RevealContent]))
+    ["semantic-ui-react$RevealContent" :as RevealContent]))
 
   (def ui-reveal-content
   "A content sub-component for the Reveal.

--- a/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.segment.ui-segment
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Segment/Segment" :default Segment]))
+    ["semantic-ui-react$Segment" :as Segment]))
 
   (def ui-segment
   "A segment is used to create a grouping of related content.

--- a/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.segment.ui-segment-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Segment/SegmentGroup" :default SegmentGroup]))
+    ["semantic-ui-react$SegmentGroup" :as SegmentGroup]))
 
   (def ui-segment-group
   "A group of segments can be formatted to appear together.

--- a/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment_inline.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/segment/ui_segment_inline.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.segment.ui-segment-inline
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Segment/SegmentInline" :default SegmentInline]))
+    ["semantic-ui-react$SegmentInline" :as SegmentInline]))
 
   (def ui-segment-inline
   "A placeholder segment can be inline.

--- a/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.step.ui-step
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Step/Step" :default Step]))
+    ["semantic-ui-react$Step" :as Step]))
 
   (def ui-step
   "A step shows the completion status of an activity in a series of activities.

--- a/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.step.ui-step-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Step/StepContent" :default StepContent]))
+    ["semantic-ui-react$StepContent" :as StepContent]))
 
   (def ui-step-content
   "A step can contain a content.

--- a/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_description.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_description.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.step.ui-step-description
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Step/StepDescription" :default StepDescription]))
+    ["semantic-ui-react$StepDescription" :as StepDescription]))
 
   (def ui-step-description
   "

--- a/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.step.ui-step-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Step/StepGroup" :default StepGroup]))
+    ["semantic-ui-react$StepGroup" :as StepGroup]))
 
   (def ui-step-group
   "A set of steps.

--- a/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_title.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/elements/step/ui_step_title.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.elements.step.ui-step-title
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/elements/Step/StepTitle" :default StepTitle]))
+    ["semantic-ui-react$StepTitle" :as StepTitle]))
 
   (def ui-step-title
   "A step can contain a title.

--- a/src/main/com/fulcrologic/semantic_ui/factories.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/factories.cljc
@@ -145,7 +145,8 @@
     - secondary (bool): A button can be formatted to show different levels of emphasis.
     - size (enum): A button can have different sizes. (mini, tiny, small, medium, large, big, huge, massive)
     - tabIndex (number|string): A button can receive focus. ()
-    - toggle (bool): A button can be formatted to toggle on and off."
+    - toggle (bool): A button can be formatted to toggle on and off.
+    - type (enum): The type of the HTML element. (button, submit, reset)"
    #?(:cljs (h/factory-apply suir/Button)))
 
 (def ui-button-content
@@ -407,7 +408,7 @@
    #?(:cljs (h/factory-apply suir/CommentText)))
 
 (def ui-confirm
-  "A Confirm modal gives the user a choice to confirm or cancel an action/
+  "A Confirm modal gives the user a choice to confirm or cancel an action.
 
   Props:
     - cancelButton (custom): The cancel button text.
@@ -652,7 +653,7 @@
     - icon (custom): Specifies an icon to use with placeholder content.
     - id (string): Specifies an id for source. ()
     - iframe (custom): Shorthand for HTML iframe. ()
-    - onClick (func): Сalled on click.
+    - onClick (func): Called on click.
     - placeholder (string): A placeholder image for embed.
     - source (enum): Specifies a source to use. (youtube, vimeo)
     - url (string): Specifies a url to use for embed. ()"
@@ -1520,13 +1521,13 @@
     - mountNode (any): The node where the modal should mount. Defaults to document.body.
     - onActionClick (func): Action onClick handler when using shorthand `actions`.
     - onClose (func): Called when a close event happens.
-    - onMount (func): Called when the portal is mounted on the DOM.
+    - onMount (func): Called when the modal is mounted on the DOM.
     - onOpen (func): Called when an open event happens.
-    - onUnmount (func): Called when the portal is unmounted from the DOM.
+    - onUnmount (func): Called when the modal is unmounted from the DOM.
     - open (bool): Controls whether or not the Modal is displayed.
     - size (enum): A modal can vary in size (mini, tiny, small, large, fullscreen)
     - style (object): Custom styles.
-    - trigger (node): Element to be rendered in-place where the portal is defined."
+    - trigger (node): Element to be rendered in-place where the modal is defined."
    #?(:cljs (h/factory-apply suir/Modal)))
 
 (def ui-modal-actions
@@ -1900,6 +1901,7 @@
     - onSearchChange (func): Called on search input change.
     - onSelectionChange (func): Called when the active selection index is changed.
     - open (bool): Controls whether or not the results menu is displayed.
+    - placeholder (string): A search can show placeholder text when empty.
     - resultRenderer (func): Renders the SearchResult contents.
     - results (arrayOf|shape): One of: ()
     - selectFirstResult (bool): Whether the search should automatically select the first result after searching.
@@ -2241,7 +2243,7 @@
     - as (elementType): An element type to render as (string or function).
     - attached (bool|enum): Attach table to other content (top, bottom)
     - basic (enum|bool): A table can reduce its complexity to increase readability. (very)
-    - celled (bool): A table may be divided each row into separate cells.
+    - celled (bool): A table may be divided into individual cells.
     - children (node): Primary content.
     - className (string): Additional classes.
     - collapsing (bool): A table can be collapsing, taking up only as much space as its rows.

--- a/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.accordion.ui-accordion
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Accordion/Accordion" :default Accordion]))
+    ["semantic-ui-react$Accordion" :as Accordion]))
 
   (def ui-accordion
   "An accordion allows users to toggle the display of sections of content.

--- a/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_accordion.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_accordion.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.accordion.ui-accordion-accordion
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Accordion/AccordionAccordion" :default AccordionAccordion]))
+    ["semantic-ui-react$AccordionAccordion" :as AccordionAccordion]))
 
   (def ui-accordion-accordion
   "An Accordion can contain sub-accordions.

--- a/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.accordion.ui-accordion-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Accordion/AccordionContent" :default AccordionContent]))
+    ["semantic-ui-react$AccordionContent" :as AccordionContent]))
 
   (def ui-accordion-content
   "A content sub-component for Accordion component.

--- a/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_panel.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_panel.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.accordion.ui-accordion-panel
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Accordion/AccordionPanel" :default AccordionPanel]))
+    ["semantic-ui-react$AccordionPanel" :as AccordionPanel]))
 
   (def ui-accordion-panel
   "A panel sub-component for Accordion component.

--- a/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_title.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/accordion/ui_accordion_title.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.accordion.ui-accordion-title
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Accordion/AccordionTitle" :default AccordionTitle]))
+    ["semantic-ui-react$AccordionTitle" :as AccordionTitle]))
 
   (def ui-accordion-title
   "A title sub-component for Accordion component.

--- a/src/main/com/fulcrologic/semantic_ui/modules/checkbox/ui_checkbox.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/checkbox/ui_checkbox.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.checkbox.ui-checkbox
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Checkbox/Checkbox" :default Checkbox]))
+    ["semantic-ui-react$Checkbox" :as Checkbox]))
 
   (def ui-checkbox
   "A checkbox allows a user to select a value from a small set of options, often binary.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dimmer.ui-dimmer
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dimmer/Dimmer" :default Dimmer]))
+    ["semantic-ui-react$Dimmer" :as Dimmer]))
 
   (def ui-dimmer
   "A dimmer hides distractions to focus attention on particular content.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer_dimmable.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer_dimmable.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dimmer.ui-dimmer-dimmable
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dimmer/DimmerDimmable" :default DimmerDimmable]))
+    ["semantic-ui-react$DimmerDimmable" :as DimmerDimmable]))
 
   (def ui-dimmer-dimmable
   "A dimmable sub-component for Dimmer.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer_inner.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dimmer/ui_dimmer_inner.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dimmer.ui-dimmer-inner
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dimmer/DimmerInner" :default DimmerInner]))
+    ["semantic-ui-react$DimmerInner" :as DimmerInner]))
 
   (def ui-dimmer-inner
   "An inner element for a Dimmer.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/Dropdown" :default Dropdown]))
+    ["semantic-ui-react$Dropdown" :as Dropdown]))
 
   (def ui-dropdown
   "A dropdown allows a user to select a value from a series of options.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_divider.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_divider.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-divider
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownDivider" :default DropdownDivider]))
+    ["semantic-ui-react$DropdownDivider" :as DropdownDivider]))
 
   (def ui-dropdown-divider
   "A dropdown menu can contain dividers to separate related content.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownHeader" :default DropdownHeader]))
+    ["semantic-ui-react$DropdownHeader" :as DropdownHeader]))
 
   (def ui-dropdown-header
   "A dropdown menu can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownItem" :default DropdownItem]))
+    ["semantic-ui-react$DropdownItem" :as DropdownItem]))
 
   (def ui-dropdown-item
   "An item sub-component for Dropdown component.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_menu.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_menu.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-menu
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownMenu" :default DropdownMenu]))
+    ["semantic-ui-react$DropdownMenu" :as DropdownMenu]))
 
   (def ui-dropdown-menu
   "A dropdown menu can contain a menu.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_search_input.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_search_input.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-search-input
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownSearchInput" :default DropdownSearchInput]))
+    ["semantic-ui-react$DropdownSearchInput" :as DropdownSearchInput]))
 
   (def ui-dropdown-search-input
   "A search item sub-component for Dropdown component.

--- a/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_text.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/dropdown/ui_dropdown_text.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-text
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Dropdown/DropdownText" :default DropdownText]))
+    ["semantic-ui-react$DropdownText" :as DropdownText]))
 
   (def ui-dropdown-text
   "A dropdown contains a selected value.

--- a/src/main/com/fulcrologic/semantic_ui/modules/embed/ui_embed.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/embed/ui_embed.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.embed.ui-embed
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Embed/Embed" :default Embed]))
+    ["semantic-ui-react$Embed" :as Embed]))
 
   (def ui-embed
   "An embed displays content from other websites like YouTube videos or Google Maps.
@@ -21,7 +21,7 @@
     - icon (custom): Specifies an icon to use with placeholder content.
     - id (string): Specifies an id for source. ()
     - iframe (custom): Shorthand for HTML iframe. ()
-    - onClick (func): Сalled on click.
+    - onClick (func): Called on click.
     - placeholder (string): A placeholder image for embed.
     - source (enum): Specifies a source to use. (youtube, vimeo)
     - url (string): Specifies a url to use for embed. ()"

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/Modal" :default Modal]))
+    ["semantic-ui-react$Modal" :as Modal]))
 
   (def ui-modal
   "A modal displays content that temporarily blocks interactions with the main view of a site.
@@ -24,11 +24,11 @@
     - mountNode (any): The node where the modal should mount. Defaults to document.body.
     - onActionClick (func): Action onClick handler when using shorthand `actions`.
     - onClose (func): Called when a close event happens.
-    - onMount (func): Called when the portal is mounted on the DOM.
+    - onMount (func): Called when the modal is mounted on the DOM.
     - onOpen (func): Called when an open event happens.
-    - onUnmount (func): Called when the portal is unmounted from the DOM.
+    - onUnmount (func): Called when the modal is unmounted from the DOM.
     - open (bool): Controls whether or not the Modal is displayed.
     - size (enum): A modal can vary in size (mini, tiny, small, large, fullscreen)
     - style (object): Custom styles.
-    - trigger (node): Element to be rendered in-place where the portal is defined."
+    - trigger (node): Element to be rendered in-place where the modal is defined."
    #?(:cljs (h/factory-apply Modal)))

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_actions.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_actions.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal-actions
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/ModalActions" :default ModalActions]))
+    ["semantic-ui-react$ModalActions" :as ModalActions]))
 
   (def ui-modal-actions
   "A modal can contain a row of actions.

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/ModalContent" :default ModalContent]))
+    ["semantic-ui-react$ModalContent" :as ModalContent]))
 
   (def ui-modal-content
   "A modal can contain content.

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_description.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_description.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal-description
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/ModalDescription" :default ModalDescription]))
+    ["semantic-ui-react$ModalDescription" :as ModalDescription]))
 
   (def ui-modal-description
   "A modal can contain a description with one or more paragraphs.

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_dimmer.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_dimmer.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal-dimmer
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/ModalDimmer" :default ModalDimmer]))
+    ["semantic-ui-react$ModalDimmer" :as ModalDimmer]))
 
   (def ui-modal-dimmer
   "A modal has a dimmer.

--- a/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/modal/ui_modal_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.modal.ui-modal-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Modal/ModalHeader" :default ModalHeader]))
+    ["semantic-ui-react$ModalHeader" :as ModalHeader]))
 
   (def ui-modal-header
   "A modal can have a header.

--- a/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.popup.ui-popup
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Popup/Popup" :default Popup]))
+    ["semantic-ui-react$Popup" :as Popup]))
 
   (def ui-popup
   "A Popup displays additional information on top of a page.

--- a/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.popup.ui-popup-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Popup/PopupContent" :default PopupContent]))
+    ["semantic-ui-react$PopupContent" :as PopupContent]))
 
   (def ui-popup-content
   "A PopupContent displays the content body of a Popover.

--- a/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/popup/ui_popup_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.popup.ui-popup-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Popup/PopupHeader" :default PopupHeader]))
+    ["semantic-ui-react$PopupHeader" :as PopupHeader]))
 
   (def ui-popup-header
   "A PopupHeader displays a header in a Popover.

--- a/src/main/com/fulcrologic/semantic_ui/modules/progress/ui_progress.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/progress/ui_progress.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.progress.ui-progress
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Progress/Progress" :default Progress]))
+    ["semantic-ui-react$Progress" :as Progress]))
 
   (def ui-progress
   "A progress bar shows the progression of a task.

--- a/src/main/com/fulcrologic/semantic_ui/modules/rating/ui_rating.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/rating/ui_rating.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.rating.ui-rating
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Rating/Rating" :default Rating]))
+    ["semantic-ui-react$Rating" :as Rating]))
 
   (def ui-rating
   "A rating indicates user interest in content.

--- a/src/main/com/fulcrologic/semantic_ui/modules/rating/ui_rating_icon.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/rating/ui_rating_icon.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.rating.ui-rating-icon
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Rating/RatingIcon" :default RatingIcon]))
+    ["semantic-ui-react$RatingIcon" :as RatingIcon]))
 
   (def ui-rating-icon
   "An internal icon sub-component for Rating component

--- a/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.search.ui-search
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Search/Search" :default Search]))
+    ["semantic-ui-react$Search" :as Search]))
 
   (def ui-search
   "A search module allows a user to query for results from a selection of data
@@ -29,6 +29,7 @@
     - onSearchChange (func): Called on search input change.
     - onSelectionChange (func): Called when the active selection index is changed.
     - open (bool): Controls whether or not the results menu is displayed.
+    - placeholder (string): A search can show placeholder text when empty.
     - resultRenderer (func): Renders the SearchResult contents.
     - results (arrayOf|shape): One of: ()
     - selectFirstResult (bool): Whether the search should automatically select the first result after searching.

--- a/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_category.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_category.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.search.ui-search-category
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Search/SearchCategory" :default SearchCategory]))
+    ["semantic-ui-react$SearchCategory" :as SearchCategory]))
 
   (def ui-search-category
   "

--- a/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_category_layout.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_category_layout.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.search.ui-search-category-layout
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Search/SearchCategoryLayout" :default SearchCategoryLayout]))
+    ["semantic-ui-react$SearchCategoryLayout" :as SearchCategoryLayout]))
 
   (def ui-search-category-layout
   "

--- a/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_result.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_result.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.search.ui-search-result
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Search/SearchResult" :default SearchResult]))
+    ["semantic-ui-react$SearchResult" :as SearchResult]))
 
   (def ui-search-result
   "

--- a/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_results.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/search/ui_search_results.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.search.ui-search-results
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Search/SearchResults" :default SearchResults]))
+    ["semantic-ui-react$SearchResults" :as SearchResults]))
 
   (def ui-search-results
   "

--- a/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.sidebar.ui-sidebar
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Sidebar/Sidebar" :default Sidebar]))
+    ["semantic-ui-react$Sidebar" :as Sidebar]))
 
   (def ui-sidebar
   "A sidebar hides additional content beside a page.

--- a/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar_pushable.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar_pushable.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.sidebar.ui-sidebar-pushable
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Sidebar/SidebarPushable" :default SidebarPushable]))
+    ["semantic-ui-react$SidebarPushable" :as SidebarPushable]))
 
   (def ui-sidebar-pushable
   "A pushable sub-component for Sidebar.

--- a/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar_pusher.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/sidebar/ui_sidebar_pusher.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.sidebar.ui-sidebar-pusher
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Sidebar/SidebarPusher" :default SidebarPusher]))
+    ["semantic-ui-react$SidebarPusher" :as SidebarPusher]))
 
   (def ui-sidebar-pusher
   "A pushable sub-component for Sidebar.

--- a/src/main/com/fulcrologic/semantic_ui/modules/sticky/ui_sticky.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/sticky/ui_sticky.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.sticky.ui-sticky
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Sticky/Sticky" :default Sticky]))
+    ["semantic-ui-react$Sticky" :as Sticky]))
 
   (def ui-sticky
   "Sticky content stays fixed to the browser viewport while another column of content is visible on the page.

--- a/src/main/com/fulcrologic/semantic_ui/modules/tab/ui_tab.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/tab/ui_tab.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.tab.ui-tab
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Tab/Tab" :default Tab]))
+    ["semantic-ui-react$Tab" :as Tab]))
 
   (def ui-tab
   "A Tab is a hidden section of content activated by a Menu.

--- a/src/main/com/fulcrologic/semantic_ui/modules/tab/ui_tab_pane.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/tab/ui_tab_pane.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.tab.ui-tab-pane
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Tab/TabPane" :default TabPane]))
+    ["semantic-ui-react$TabPane" :as TabPane]))
 
   (def ui-tab-pane
   "A tab pane holds the content of a tab.

--- a/src/main/com/fulcrologic/semantic_ui/modules/transition/ui_transition.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/transition/ui_transition.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.transition.ui-transition
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Transition/Transition" :default Transition]))
+    ["semantic-ui-react$Transition" :as Transition]))
 
   (def ui-transition
   "A transition is an animation usually used to move content in or out of view.

--- a/src/main/com/fulcrologic/semantic_ui/modules/transition/ui_transition_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/modules/transition/ui_transition_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.modules.transition.ui-transition-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/modules/Transition/TransitionGroup" :default TransitionGroup]))
+    ["semantic-ui-react$TransitionGroup" :as TransitionGroup]))
 
   (def ui-transition-group
   "A Transition.Group animates children as they mount and unmount.

--- a/src/main/com/fulcrologic/semantic_ui/views/advertisement/ui_advertisement.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/advertisement/ui_advertisement.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.advertisement.ui-advertisement
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Advertisement/Advertisement" :default Advertisement]))
+    ["semantic-ui-react$Advertisement" :as Advertisement]))
 
   (def ui-advertisement
   "An ad displays third-party promotional content.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/Card" :default Card]))
+    ["semantic-ui-react$Card" :as Card]))
 
   (def ui-card
   "A card displays site content in a manner similar to a playing card.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/CardContent" :default CardContent]))
+    ["semantic-ui-react$CardContent" :as CardContent]))
 
   (def ui-card-content
   "A card can contain blocks of content or extra content meant to be formatted separately from the main content.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_description.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_description.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card-description
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/CardDescription" :default CardDescription]))
+    ["semantic-ui-react$CardDescription" :as CardDescription]))
 
   (def ui-card-description
   "A card can contain a description with one or more paragraphs.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/CardGroup" :default CardGroup]))
+    ["semantic-ui-react$CardGroup" :as CardGroup]))
 
   (def ui-card-group
   "A group of cards.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/CardHeader" :default CardHeader]))
+    ["semantic-ui-react$CardHeader" :as CardHeader]))
 
   (def ui-card-header
   "A card can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_meta.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/card/ui_card_meta.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.card.ui-card-meta
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Card/CardMeta" :default CardMeta]))
+    ["semantic-ui-react$CardMeta" :as CardMeta]))
 
   (def ui-card-meta
   "A card can contain content metadata.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/Comment" :default Comment]))
+    ["semantic-ui-react$Comment" :as Comment]))
 
   (def ui-comment
   "A comment displays user feedback to site content.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_action.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_action.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-action
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentAction" :default CommentAction]))
+    ["semantic-ui-react$CommentAction" :as CommentAction]))
 
   (def ui-comment-action
   "A comment can contain an action.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_actions.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_actions.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-actions
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentActions" :default CommentActions]))
+    ["semantic-ui-react$CommentActions" :as CommentActions]))
 
   (def ui-comment-actions
   "A comment can contain an list of actions a user may perform related to this comment.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_author.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_author.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-author
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentAuthor" :default CommentAuthor]))
+    ["semantic-ui-react$CommentAuthor" :as CommentAuthor]))
 
   (def ui-comment-author
   "A comment can contain an author.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_avatar.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_avatar.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-avatar
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentAvatar" :default CommentAvatar]))
+    ["semantic-ui-react$CommentAvatar" :as CommentAvatar]))
 
   (def ui-comment-avatar
   "A comment can contain an image or avatar.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentContent" :default CommentContent]))
+    ["semantic-ui-react$CommentContent" :as CommentContent]))
 
   (def ui-comment-content
   "A comment can contain content.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentGroup" :default CommentGroup]))
+    ["semantic-ui-react$CommentGroup" :as CommentGroup]))
 
   (def ui-comment-group
   "Comments can be grouped.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_metadata.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_metadata.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-metadata
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentMetadata" :default CommentMetadata]))
+    ["semantic-ui-react$CommentMetadata" :as CommentMetadata]))
 
   (def ui-comment-metadata
   "A comment can contain metadata about the comment, an arbitrary amount of metadata may be defined.

--- a/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_text.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/comment/ui_comment_text.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.comment.ui-comment-text
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Comment/CommentText" :default CommentText]))
+    ["semantic-ui-react$CommentText" :as CommentText]))
 
   (def ui-comment-text
   "A comment can contain text.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/Feed" :default Feed]))
+    ["semantic-ui-react$Feed" :as Feed]))
 
   (def ui-feed
   "A feed presents user activity chronologically.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedContent" :default FeedContent]))
+    ["semantic-ui-react$FeedContent" :as FeedContent]))
 
   (def ui-feed-content
   "

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_date.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_date.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-date
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedDate" :default FeedDate]))
+    ["semantic-ui-react$FeedDate" :as FeedDate]))
 
   (def ui-feed-date
   "An event or an event summary can contain a date.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_event.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_event.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-event
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedEvent" :default FeedEvent]))
+    ["semantic-ui-react$FeedEvent" :as FeedEvent]))
 
   (def ui-feed-event
   "A feed contains an event.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_extra.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_extra.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-extra
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedExtra" :default FeedExtra]))
+    ["semantic-ui-react$FeedExtra" :as FeedExtra]))
 
   (def ui-feed-extra
   "A feed can contain an extra content.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_label.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_label.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-label
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedLabel" :default FeedLabel]))
+    ["semantic-ui-react$FeedLabel" :as FeedLabel]))
 
   (def ui-feed-label
   "An event can contain an image or icon label.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_like.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_like.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-like
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedLike" :default FeedLike]))
+    ["semantic-ui-react$FeedLike" :as FeedLike]))
 
   (def ui-feed-like
   "A feed can contain a like element.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_meta.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_meta.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-meta
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedMeta" :default FeedMeta]))
+    ["semantic-ui-react$FeedMeta" :as FeedMeta]))
 
   (def ui-feed-meta
   "A feed can contain a meta.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_summary.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_summary.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-summary
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedSummary" :default FeedSummary]))
+    ["semantic-ui-react$FeedSummary" :as FeedSummary]))
 
   (def ui-feed-summary
   "A feed can contain a summary.

--- a/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_user.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/feed/ui_feed_user.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.feed.ui-feed-user
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Feed/FeedUser" :default FeedUser]))
+    ["semantic-ui-react$FeedUser" :as FeedUser]))
 
   (def ui-feed-user
   "A feed can contain a user element.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/Item" :default Item]))
+    ["semantic-ui-react$Item" :as Item]))
 
   (def ui-item
   "An item view presents large collections of site content for display.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_content.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_content.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-content
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemContent" :default ItemContent]))
+    ["semantic-ui-react$ItemContent" :as ItemContent]))
 
   (def ui-item-content
   "An item can contain content.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_description.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_description.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-description
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemDescription" :default ItemDescription]))
+    ["semantic-ui-react$ItemDescription" :as ItemDescription]))
 
   (def ui-item-description
   "An item can contain a description with a single or multiple paragraphs.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_extra.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_extra.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-extra
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemExtra" :default ItemExtra]))
+    ["semantic-ui-react$ItemExtra" :as ItemExtra]))
 
   (def ui-item-extra
   "An item can contain extra content meant to be formatted separately from the main content.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemGroup" :default ItemGroup]))
+    ["semantic-ui-react$ItemGroup" :as ItemGroup]))
 
   (def ui-item-group
   "A group of items.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_header.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_header.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-header
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemHeader" :default ItemHeader]))
+    ["semantic-ui-react$ItemHeader" :as ItemHeader]))
 
   (def ui-item-header
   "An item can contain a header.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_image.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_image.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-image
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemImage" :default ItemImage]))
+    ["semantic-ui-react$ItemImage" :as ItemImage]))
 
   (def ui-item-image
   "An item can contain an image.

--- a/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_meta.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/item/ui_item_meta.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.item.ui-item-meta
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Item/ItemMeta" :default ItemMeta]))
+    ["semantic-ui-react$ItemMeta" :as ItemMeta]))
 
   (def ui-item-meta
   "An item can contain content metadata.

--- a/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.statistic.ui-statistic
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Statistic/Statistic" :default Statistic]))
+    ["semantic-ui-react$Statistic" :as Statistic]))
 
   (def ui-statistic
   "A statistic emphasizes the current value of an attribute.

--- a/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_group.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_group.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.statistic.ui-statistic-group
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Statistic/StatisticGroup" :default StatisticGroup]))
+    ["semantic-ui-react$StatisticGroup" :as StatisticGroup]))
 
   (def ui-statistic-group
   "A group of statistics.

--- a/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_label.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_label.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.statistic.ui-statistic-label
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Statistic/StatisticLabel" :default StatisticLabel]))
+    ["semantic-ui-react$StatisticLabel" :as StatisticLabel]))
 
   (def ui-statistic-label
   "A statistic can contain a label to help provide context for the presented value.

--- a/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_value.cljc
+++ b/src/main/com/fulcrologic/semantic_ui/views/statistic/ui_statistic_value.cljc
@@ -1,7 +1,7 @@
 (ns com.fulcrologic.semantic-ui.views.statistic.ui-statistic-value
   (:require
     [com.fulcrologic.semantic-ui.factory-helpers :as h]
-    ["semantic-ui-react/dist/commonjs/views/Statistic/StatisticValue" :default StatisticValue]))
+    ["semantic-ui-react$StatisticValue" :as StatisticValue]))
 
   (def ui-statistic-value
   "A statistic can contain a numeric, icon, image, or text value.


### PR DESCRIPTION
This makes semantic-ui-wrapper usable by ClojureScript, while keeping compatibility with shadow-cljs.

This support requires ClojureScript v1.10.844, released April 2021: https://clojurescript.org/news/2021-04-06-release#_library_property_namespaces 

Some minor modifications to the documentation being generated are also present. 

I kept the three commits separate, to split the generation from the changes.